### PR TITLE
change xtcavf from an lcavity into a crab_cavity

### DIFF
--- a/bmad/master/LI20.bmad
+++ b/bmad/master/LI20.bmad
@@ -744,7 +744,8 @@ as1er[ref] = s1er
 
 lxtcav = 40.687*in2m
 
-xtcavf: lcavity, rf_frequency = 11424 * 1e6, type = "TRANS_DEFL", l = lxtcav/2
+xtcavf: crab_cavity, rf_frequency = 11424 * 1e6, type = "TRANS_DEFL", l = lxtcav/2,
+                     voltage=0, phi0=0
 
 ! ==============================================================================
 ! BENDs


### PR DESCRIPTION
xtcavf is a transverse deflecting cavity, not an lcavity.  Change element type from lcavity to crab_cavity.