### PR TITLE
options for exploring off energy optics in sector20

### DIFF
--- a/bmad/models/f2_elec/f2_elec.lat.bmad
+++ b/bmad/models/f2_elec/f2_elec.lat.bmad
@@ -23,6 +23,8 @@ beginning[z_position] = 1002.27394413849
 call, file = $FACET2_LATTICE/bmad/master/F2_ELEC.bmad
 call, file = $FACET2_LATTICE/bmad/master/FACET2e_devicenames.bmad
 
+patch_sector20: patch, superimpose, ref=begff20
+
 ! ! MRK0F (near PR10571)
 ! QA10361[K1] = -9.99949223070979443E+000
 ! QA10371[K1] =  9.61829456887900136E+000
@@ -72,3 +74,4 @@ beginning[e_tot] = 6e6
 !beginning[s] = 0.426796 + .015 - (4.908185 - 4.908934)
 
 lcavity::*[num_steps] = 50
+!bmad_com[absolute_time_tracking]=t

--- a/bmad/models/f2_elec/sector20.bmad
+++ b/bmad/models/f2_elec/sector20.bmad
@@ -15,5 +15,10 @@ beginning[etap_y] = 0.0
 beginning[s] = 978.620876
 beginning[ref_time] = 3.264345E-06
 beginning[z_position] = 1977.71806
+beginning[x_position] = 0.0
+beginning[y_position] = 0.0
+beginning[theta_position] = 0
+beginning[phi_position] = 0
+beginning[psi_position] = 0
 
 

--- a/bmad/models/f2_elec/sector20.bmad
+++ b/bmad/models/f2_elec/sector20.bmad
@@ -1,0 +1,19 @@
+call, file = f2_elec.lat.bmad
+use, ff20h
+
+beginning[e_tot] = 10.0e9
+beginning[beta_a] = 11.07912149
+beginning[beta_b] = 24.01796393
+beginning[alpha_a] = -0.59373605
+beginning[alpha_b] = -1.51568862
+beginning[phi_a] = 71.27618846
+beginning[phi_b] = 56.23806195
+beginning[eta_x] = 0.00001784
+beginning[eta_y] = 0.0
+beginning[etap_x] = 0.00000119
+beginning[etap_y] = 0.0
+beginning[s] = 978.620876
+beginning[ref_time] = 3.264345E-06
+beginning[z_position] = 1977.71806
+
+

--- a/bmad/models/f2_elec/sector20_patch.bmad
+++ b/bmad/models/f2_elec/sector20_patch.bmad
@@ -1,0 +1,4 @@
+call, file = f2_elec.lat.bmad
+
+patch_sector20: patch, E_tot_set=8.0e9, superimpose, ref=begff20
+


### PR DESCRIPTION
Added a lattice file sector20.bmad, which contains the lattice starting immediately after BC20.  sector20.bmad contains beginning statements to allow the incoming beam to be adjusted freely.