### PR TITLE
add fixer element for cathode twiss

### DIFF
--- a/bmad/models/f2_elec/f2_elec.lat.bmad
+++ b/bmad/models/f2_elec/f2_elec.lat.bmad
@@ -76,6 +76,11 @@ l0bf[n_rf_steps]=5000
 lcavity::k11_*[n_rf_steps]=5000
 !lcavity::*[n_cell] = 0
 
+fixer_inj: fixer, superimpose, ref=beginning, ref_origin=beginning,
+  beta_a_stored=1.3945E-01, alpha_a_stored=9.5114E-01,
+  beta_b_stored=3.6536E-01, alpha_b_stored=1.9962E+00,
+  is_on=F
+
 fixer_mrk0f: fixer, superimpose, ref=mrk0f, ref_origin=beginning,
   beta_a_stored=5.286, alpha_a_stored=-2.039,
   beta_b_stored=2.582, alpha_b_stored=0.052,


### PR DESCRIPTION
I need to define one more fixer element for the beginning twiss. This is so we can set the twiss at the fixer element `<ele>`, where ops measure emittances, then switch to an upstream fixer so the twiss at the measurement location can be varied.
-> ops measure twiss parameters at `<ele>`
-> activate `fixer_<ele>`, set betas/alphas to measured values
-> save `fixer_inj` (the cathode) with propagated value from the downstream fixer
-> activate `fixer_inj` so the twiss parameters are free to vary again at `<ele>`
-> use data for twiss defined at `<ele>` and upstream matching quads as varsity, run the tao optimizer to match optics back to design at `<ele>`

In particular,  `<ele>` is one of `pr10571`, `ws11444`, `ws11614`, `ws12214` and `ws19144`